### PR TITLE
Variability Candidates: add GALEX data

### DIFF
--- a/scripts/retrieve_variability_candidates.py
+++ b/scripts/retrieve_variability_candidates.py
@@ -7,6 +7,7 @@ from zvartools.candidate import (
     add_ps1_xmatch_to_candidates,
     add_2mass_xmatch_to_candidates,
     add_allwise_xmatch_to_candidates,
+    add_galex_xmatch_to_candidates,
 )
 from zvartools.external import connect_to_kowalski
 from zvartools.parsers import candidates_parser, validate_candidates_args
@@ -62,6 +63,10 @@ if __name__ == "__main__":
             candidate_list = add_allwise_xmatch_to_candidates(
                 k, candidate_list, radius
             )  # Fill in the AllWISE data
+            print("Adding GALEX xmatch to candidates")
+            candidate_list = add_galex_xmatch_to_candidates(
+                k, candidate_list, radius
+            )  # Fill in the GALEX data
             print("Exporting candidates to CSV")
             export_to_parquet(
                 candidate_list, field, band, output_path

--- a/src/zvartools/external.py
+++ b/src/zvartools/external.py
@@ -601,6 +601,8 @@ def query_galex(
             "dec": 1,
             "name": 1,
             "b": 1,
+            "FUVmag": 1,
+            "e_FUVmag": 1,
             "NUVmag": 1,
             "e_NUVmag": 1,
         },


### PR DESCRIPTION
This PR adds the code necessary to take advantage of the existing `query_galex` method, to add Galex data to the variability candidate datasets that we can make with `scripts/retrieve_variability_candidates`. The resulting galex data can then be used for filtering and plotting, like any other xmatch data product.

TODOs:
- [x] agree with the implementation team which columns/fields from Galex we want to keep